### PR TITLE
Add EnumKit and RxEnumKit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -365,6 +365,8 @@
   "https://github.com/google/open-location-code-swift.git",
   "https://github.com/google/promises.git",
   "https://github.com/graycampbell/GCCountryPicker.git",
+  "https://github.com/gringoireDM/EnumKit.git",
+  "https://github.com/gringoireDM/RxEnumKit.git",
   "https://github.com/groue/GRDB.swift.git",
   "https://github.com/groue/GRMustache.swift.git",
   "https://github.com/grpc/grpc-swift.git",


### PR DESCRIPTION
EnumKit is a library that gives you the ability to simply access an enum associated value, without having to use pattern matching. It also offers many utilities available to other swift types, like updatability of an associated value and transformations.

```swift
enum Foo: CaseAccessible {
    case bar(String)
    case baz
}

let f: Foo
let value = f[case: Foo.bar] // String?
```

RxEnumKit is its extension for the RxSwift world to work with stream of events expressed as enums.