### PR TITLE
Remove apodidae

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1487,7 +1487,6 @@
   "https://github.com/khoogheem/bootstrapprovider.git",
   "https://github.com/KieranHarper/Yakka.git",
   "https://github.com/kiliankoe/anybarswift.git",
-  "https://github.com/kiliankoe/apodidae.git",
   "https://github.com/kiliankoe/CLISpinner.git",
   "https://github.com/kiliankoe/cnkit.git",
   "https://github.com/kiliankoe/Corkboard.git",


### PR DESCRIPTION
Apodidae was renamed to SwiftLibrary (which is also included) and therefore appears twice in the list 🙈 

<img width="630" alt="Screenshot 2019-10-03 at 13 45 36" src="https://user-images.githubusercontent.com/2625584/66124253-3241fb80-e5e4-11e9-9dee-6e0d70dfb19f.png">