### PR TITLE
UIViewPreview + @UseAutoLayout

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -346,6 +346,8 @@
   "https://github.com/BiAtoms/Xml.swift.git",
   "https://github.com/bibinjacobpulickal/AutoLayoutProxy.git",
   "https://github.com/bielikb/textattributes.git",
+  "https://github.com/bielikb/UIViewPreview",
+  "https://github.com/bielikb/UseAutoLayout",
   "https://github.com/bignerdranch/Deferred.git",
   "https://github.com/bikemap/lingohubcli.git",
   "https://github.com/Bilue/ContentFittingWebView.git",


### PR DESCRIPTION
Packages:
`UIViewPreview` - allows you to preview your UIKit UIViews in SwiftUI preview (Xcode 11.0+, macOS Catalina)

`UseAutoLayout` - property wrapper that enables autolayout on applied views.