### PR TITLE
Better output when packages are not sorted.

### DIFF
--- a/validate.swift
+++ b/validate.swift
@@ -453,17 +453,15 @@ if command == .mine {
   }
 
   guard unsortedUrls.count == 0 else {
-    print("Error: packages.json is not sorted: \(unsortedUrls)")
     // If the sorting fails, save the sorted packages.json file
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted]
-
     let data = try! encoder.encode(sortedUrls)
     let str = String(data: data, encoding: .utf8)!.replacingOccurrences(of: "\\/", with: "/")
     let unescapedData = str.data(using: .utf8)!
     let outputURL = url.deletingPathExtension().appendingPathExtension("sorted.json")
     try! unescapedData.write(to: outputURL)
-    print("Sorted packages.json has been saved to:\n \(outputURL.path)")
+    print("Error: Packages.json is not sorted correctly. Run this validation locally and replace packages.json with packages.sorted.json.")
     exit(1)
   }
 


### PR DESCRIPTION
People were not understanding what to do with packages.sorted.json and were trying to commit packages.sorted.json.

I think this is because the output from a bad sort was quite noisy and hard to understand, especially in CI builds. Hopefully, this will help.

/cc @leogdion 