### PR TITLE
Remove duplicate png package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1114,7 +1114,6 @@
   "https://github.com/keithpitsui/paversfrp.git",
   "https://github.com/keithpitsui/paversparsec.git",
   "https://github.com/kellanburket/franz.git",
-  "https://github.com/kelvin13/maxpng.git",
   "https://github.com/kelvin13/noise.git",
   "https://github.com/kelvin13/png.git",
   "https://github.com/kelvin13/swift-opengl.git",


### PR DESCRIPTION
This repository was renamed from `maxpng` to `png` and then it was added again in the list:  
making the package show up twice in the results.

This PR removes only the _old_ link.

(the current correct link,  `https://github.com/kelvin13/png.git`, is still in the list 👍 )