### PR TITLE
Add MacAddress package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -833,6 +833,7 @@
   "https://github.com/gwynne/iniserialization.git",
   "https://github.com/h2glab/gitlab-provider.git",
   "https://github.com/hackiftekhar/IQKeyboardManager.git",
+  "https://github.com/haekelmeister/MacAddress.git",
   "https://github.com/halcyonmobile/ReleaseRadar.git",
   "https://github.com/halcyonmobile/RestBird.git",
   "https://github.com/hallee/dotfiles.git",


### PR DESCRIPTION
MacAddress is EUI-48 datatype for Swift.