### PR TITLE
Remove Vapor open-crypto duplicates

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2351,8 +2351,6 @@
   "https://github.com/vapor-community/wkhtmltopdf.git",
   "https://github.com/vapor/auth.git",
   "https://github.com/vapor/core.git",
-  "https://github.com/vapor/crypto-kit.git",
-  "https://github.com/vapor/crypto.git",
   "https://github.com/vapor/database-kit.git",
   "https://github.com/vapor/fluent-mongo-driver.git",
   "https://github.com/vapor/http.git",


### PR DESCRIPTION
All these repositories redirect to https://github.com/vapor/open-crypto now