### PR TITLE
add Matft

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1053,6 +1053,7 @@
   "https://github.com/Jimmy-Lee/Networking.git",
   "https://github.com/jinxiansen/guardian.git",
   "https://github.com/jjc1138/tiny-events.git",
+  "https://github.com/jjjkkkjjj/Matft.git",
   "https://github.com/jjochen/JJFloatingActionButton.git",
   "https://github.com/JKalash/Croc.git",
   "https://github.com/jkandzi/Progress.swift.git",


### PR DESCRIPTION
Please add [Matft](https://github.com/jjjkkkjjj/Matft). Matft is numpy-like library in Swift.